### PR TITLE
Fix the nav bar issue

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,6 +14,12 @@ github_username:  LSFLK
 # Build settings
 theme: minima
 
+# Force custom navigation
+header_pages:
+  - about.md
+  - team.md
+  - projects.md
+
 # Collections
 collections:
   projects:

--- a/_config.yml
+++ b/_config.yml
@@ -16,8 +16,8 @@ theme: minima
 
 # Force custom navigation
 header_pages:
-  - about.md
-  - team.md
+  - ./about/index.md
+  - ./team/index.md
   - projects.md
 
 # Collections

--- a/_config.yml
+++ b/_config.yml
@@ -16,8 +16,8 @@ theme: minima
 
 # Force custom navigation
 header_pages:
-  - ./about/index.md
-  - ./team/index.md
+  - about/index.md
+  - team/index.md
   - projects.md
 
 # Collections


### PR DESCRIPTION
- Previously, the site header showed unintended links such as _Board of Directors_ and _Our Engineers_, etc which should only appear within the Team page. This was caused by a path issue.

<img width="2428" height="418" alt="image" src="https://github.com/user-attachments/assets/84f6d6a8-64f2-49de-b93c-6f3a576bc497" />

- This PR fixes the problem by defining the correct header_pages in `_config.yml`. Now the header only shows the intended links: About, Team, and Projects.

<img width="2346" height="318" alt="image" src="https://github.com/user-attachments/assets/8277a228-3925-47fb-bf55-0c6e1877105c" />